### PR TITLE
Update storage accounts to use TLS 1.2

### DIFF
--- a/storage-account/main.tf
+++ b/storage-account/main.tf
@@ -30,6 +30,7 @@ resource "azurerm_storage_account" "main" {
   location                          = var.location 
   account_tier                      = "Standard"
   account_replication_type          = "LRS"
-  is_hns_enabled                    = var.is_hns_enabled
+  is_hns_enabled                    = var.is_hns_enabled  
+  min_tls_version                   = "TLS1_2"
   tags                              = var.tags
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-terraform-modules) before we can accept your contribution. --->

## Description

Updates storage accounts to use TLS 1.2 which is now required by our security settings

## References

