### PR TITLE
feat: Add support for queue sessions

### DIFF
--- a/service-bus-queue/main.tf
+++ b/service-bus-queue/main.tf
@@ -25,6 +25,7 @@ resource "azurerm_servicebus_queue" "main" {
   name                = var.name
   resource_group_name = var.resource_group_name
   namespace_name      = var.namespace_name
-
+  
+  requires_session    = var.requires_session
   enable_partitioning = true
 }

--- a/service-bus-queue/variables.tf
+++ b/service-bus-queue/variables.tf
@@ -26,6 +26,12 @@ variable resource_group_name {
   description = "(Required) The name of the resource group in which to create the namespace. Changing this forces a new resource to be created."
 }
 
+variable requires_session {
+  type        = bool
+  description = "(Optional) Should the queue require sessions? Defaults to false"
+  default     = false
+}
+
 variable tags {
   type        = any
   description = "(Optional) A mapping of tags to assign to the resource."


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-terraform-modules) before we can accept your contribution. --->

## Description

The purpose of this PR is to add support for service bus queues to require sessions, which is needed for the post office domain.

## References
