### PR TITLE
6.0.0 Servicebus update

### DIFF
--- a/azure/service-bus-namespace/README.md
+++ b/azure/service-bus-namespace/README.md
@@ -10,7 +10,7 @@
 
 This module creates the following resources.
 
-- [Azure Service Bus Namespace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_bus_namespace)
+- [Azure Service Bus Namespace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace)
 - [Azure Service Bus Namespace Authorization Rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace_authorization_rule)
 
 ## Prerequisites
@@ -32,6 +32,7 @@ This module creates the following resources.
 | `auth_rules` | `list` | | **Required** | A list of objects describing the auth rules of the Service Bus Namespace. See [Auth Rule](#auth-rule). |
 | `private_endpoint_subnet_id` | `string` | | **Required**  | The ID of the private endpoint subnet
 | `private_dns_resource_group_name` | `string` | | **Required**  | Specifies the resource group where the Private DNS Zone exists. Changing this forces a new resource to be created.
+| `capacity` | `number` | `1` | | The capcity when using premium sku. |
 | `tags` | `string` | `{}` | | A mapping of tags to assign to the resource. |
 
 ### Auth Rule
@@ -46,7 +47,7 @@ This module creates the following resources.
 ## Usage
 
 ```ruby
-module "service_bus_namespace_example" { 
+module "service_bus_namespace_example" {
   source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-namespace?ref=5.1.0"
 
   name                  = "example-name"
@@ -76,7 +77,7 @@ Two tags is added by default
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "5.1.0"
+    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-service-bus-namespace"
   }
 }

--- a/azure/service-bus-namespace/README.md
+++ b/azure/service-bus-namespace/README.md
@@ -49,7 +49,7 @@ This module creates the following resources:
 
 ```ruby
 module "service_bus_namespace_example" {
-  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-namespace?ref=5.1.0"
+  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-namespace?ref=6.0.0"
 
   name                  = "example-name"
   project_name          = "example-project-name"

--- a/azure/service-bus-namespace/README.md
+++ b/azure/service-bus-namespace/README.md
@@ -8,7 +8,9 @@
 
 ## Resources Created
 
-This module creates the following resources.
+**Notice:** This module always creates a Service Bus with SKU = Premium (to support VNet).
+
+This module creates the following resources:
 
 - [Azure Service Bus Namespace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace)
 - [Azure Service Bus Namespace Authorization Rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace_authorization_rule)
@@ -19,8 +21,6 @@ This module creates the following resources.
 - AzureRM provider version 2.91.0+
 
 ## Arguments and defaults
-
-**Notice:** This module always creates a Service Bus with SKU = Premium (to support VNet).
 
 | Name | Type | Default | Required | Description |
 |-|-|-|-|-|

--- a/azure/service-bus-namespace/README.md
+++ b/azure/service-bus-namespace/README.md
@@ -20,6 +20,8 @@ This module creates the following resources.
 
 ## Arguments and defaults
 
+**Notice:** This module always creates a Service Bus with SKU = Premium (to support VNet).
+
 | Name | Type | Default | Required | Description |
 |-|-|-|-|-|
 | `name` | `string` | | **Required** | The name of the Microsoft SQL Server. This needs to be globally unique within Azure. The final name of the resource will follow this syntax `sb-{var.name}-${var.environment_short}-${var.environment_instance}` and be in lowercase. |
@@ -28,7 +30,6 @@ This module creates the following resources.
 | `environment_instance` | `string` | | **Required** |  The instance number of your environment. |
 | `resource_group_name` | `string` | | **Required** | The name of the resource group in which to create the Function App. |
 | `location` | `string` | | **Required** | Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. |
-| `sku` | `string` | | **Required** | Defines which tier to use. Options are `basic`, `standard` or `premium`. Changing this forces a new resource to be created. |
 | `auth_rules` | `list` | | **Required** | A list of objects describing the auth rules of the Service Bus Namespace. See [Auth Rule](#auth-rule). |
 | `private_endpoint_subnet_id` | `string` | | **Required**  | The ID of the private endpoint subnet
 | `private_dns_resource_group_name` | `string` | | **Required**  | Specifies the resource group where the Private DNS Zone exists. Changing this forces a new resource to be created.
@@ -56,7 +57,6 @@ module "service_bus_namespace_example" {
   environment_instance  = "001"
   resource_group_name   = "example-resource-group-name"
   location              = "westeurope"
-  sku                   = "basic"
   auth_rules            = [
     {
       name    = "example-auth-rule-1"

--- a/azure/service-bus-namespace/main.tf
+++ b/azure/service-bus-namespace/main.tf
@@ -24,6 +24,7 @@ resource "azurerm_servicebus_namespace" "this" {
   resource_group_name = var.resource_group_name
   sku                 = var.sku
   capacity            = var.capacity
+
   tags                = merge(var.tags, local.module_tags)
 
   lifecycle {

--- a/azure/service-bus-namespace/main.tf
+++ b/azure/service-bus-namespace/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_servicebus_namespace" "this" {
   name                = "sb-${lower(var.name)}-${lower(var.project_name)}-${lower(var.environment_short)}-${lower(var.environment_instance)}"
   location            = var.location
   resource_group_name = var.resource_group_name
-  sku                 = var.sku
+  sku                 = "Premium"
   capacity            = var.capacity
 
   tags                = merge(var.tags, local.module_tags)

--- a/azure/service-bus-namespace/variables.tf
+++ b/azure/service-bus-namespace/variables.tf
@@ -47,11 +47,6 @@ variable location {
   description = "(Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created."
 }
 
-variable sku {
-  type        = string
-  description = "(Required) Defines which tier to use. Options are basic, standard or premium. Changing this forces a new resource to be created."
-}
-
 variable auth_rules {
   type        = list(object({
     name    = string
@@ -74,12 +69,12 @@ variable private_dns_resource_group_name {
 
 variable capacity {
   type        = number
-  description = "(Optional) The capcity when using premium sku"
+  description = "(Optional) The capcity when using premium sku."
   default     = 1
   validation {
     condition     = contains([1,2,4,8,16], var.capacity)
     error_message = "Valid values for var: capacity are (1,2,4,8,16)."
-  } 
+  }
 }
 
 variable tags {

--- a/azure/service-bus-queue/README.md
+++ b/azure/service-bus-queue/README.md
@@ -8,14 +8,16 @@
 
 ## Resources Created
 
-This module creates the following resources.
+**Notice**: [Partitioning is not support when using Premium Messaging](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging#partitioned-queues-and-topics)
+
+This module creates the following resources:
 
 - [Azure Service Bus Queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_queue)
 
 ## Prerequisites
 
 - Terraform version 1.0.6+
-- AzureRM provider version 2.71.0+
+- AzureRM provider version 2.91.0+
 
 ## Arguments and defaults
 
@@ -30,7 +32,7 @@ This module creates the following resources.
 
 ```ruby
 module "service_bus_queue_example" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-queue?ref=5.1.0"
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-queue?ref=6.0.0"
   name                = "example-name"
   namespace_id        = "/subscriptions/<subscription id>/resourceGroups/<resource group>/providers/Microsoft.ServiceBus/namespaces/example-namespace-name"
 }

--- a/azure/service-bus-queue/README.md
+++ b/azure/service-bus-queue/README.md
@@ -10,7 +10,7 @@
 
 This module creates the following resources.
 
-- [Azure Service Bus Queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_bus_queue)
+- [Azure Service Bus Queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_queue)
 
 ## Prerequisites
 

--- a/azure/service-bus-queue/README.md
+++ b/azure/service-bus-queue/README.md
@@ -15,25 +15,24 @@ This module creates the following resources.
 ## Prerequisites
 
 - Terraform version 1.0.6+
-- AzureRM provider version 2.70.0+
+- AzureRM provider version 2.71.0+
 
 ## Arguments and defaults
 
 | Name | Type | Default | Required | Description |
 |-|-|-|-|-|
 | `name` | `string` | | **Required** | Specifies the name of the Service Bus Queue resource. Changing this forces a new resource to be created. The final name will be lowercased. |
-| `resource_group_name` | `string` | | **Required** | The name of the resource group in which to create the queue. Changing this forces a new resource to be created. |
-| `namespace_name` | `string` | | **Required** | The name of the Service Bus Namespace to create this queue in. Changing this forces a new resource to be created. |
+| `namespace_id` | `string` | | **Required** | The ID of the Service Bus Namespace to create this queue in. Changing this forces a new resource to be created. |
 | `requires_session` | `false` | | | Boolean flag which controls whether the Queue requires sessions. This will allow ordered handling of unbounded sequences of related messages. With sessions enabled a queue can guarantee first-in-first-out delivery of messages. Changing this forces a new resource to be created. Defaults to false. |
 | `requires_duplicate_detection` | `false` | | | Boolean flag which controls whether the Queue checks for duplicate messages within a time frame of 10 minutes (default). Changing this forces a new resource to be created. Defaults to false. |
 
 ## Usage
 
 ```ruby
-module "service_bus_queue_example" { 
+module "service_bus_queue_example" {
   source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-queue?ref=5.1.0"
   name                = "example-name"
-  namespace_name      = "example-namespace-name"
+  namespace_id        = "/subscriptions/<subscription id>/resourceGroups/<resource group>/providers/Microsoft.ServiceBus/namespaces/example-namespace-name"
 }
 ```
 

--- a/azure/service-bus-queue/main.tf
+++ b/azure/service-bus-queue/main.tf
@@ -16,5 +16,4 @@ resource "azurerm_servicebus_queue" "this" {
   namespace_id                 = var.namespace_id
   requires_session             = var.requires_session
   requires_duplicate_detection = var.requires_duplicate_detection
-  enable_partitioning          = true
 }

--- a/azure/service-bus-queue/main.tf
+++ b/azure/service-bus-queue/main.tf
@@ -13,8 +13,7 @@
 # limitations under the License.
 resource "azurerm_servicebus_queue" "this" {
   name                         = lower(var.name)
-  resource_group_name          = var.resource_group_name
-  namespace_name               = var.namespace_name
+  namespace_id                 = var.namespace_id
   requires_session             = var.requires_session
   requires_duplicate_detection = var.requires_duplicate_detection
   enable_partitioning          = true

--- a/azure/service-bus-queue/variables.tf
+++ b/azure/service-bus-queue/variables.tf
@@ -23,12 +23,12 @@ variable namespace_id {
 
 variable requires_session {
   type        = bool
-  description = "(Optional) Should the queue require sessions? Defaults to false"
+  description = "(Optional) Should the queue require sessions? Defaults to false."
   default     = false
 }
 
 variable requires_duplicate_detection {
   type        = bool
-  description = "(Optional) Should the queue require duplicate detection? Defaults to false"
+  description = "(Optional) Should the queue require duplicate detection? Defaults to false."
   default     = false
 }

--- a/azure/service-bus-queue/variables.tf
+++ b/azure/service-bus-queue/variables.tf
@@ -16,14 +16,9 @@ variable name {
   description = "(Required) Specifies the name of the Service Bus Queue resource. Changing this forces a new resource to be created."
 }
 
-variable resource_group_name {
+variable namespace_id {
   type        = string
-  description = "(Required) The name of the resource group in which to create the queue. Changing this forces a new resource to be created."
-}
-
-variable namespace_name {
-  type        = string
-  description = "(Required) The name of the Service Bus Namespace to create this queue in. Changing this forces a new resource to be created."
+  description = "(Required) The ID of the ServiceBus Namespace to create this queue in. Changing this forces a new resource to be created."
 }
 
 variable requires_session {

--- a/azure/service-bus-topic/README.md
+++ b/azure/service-bus-topic/README.md
@@ -8,7 +8,9 @@
 
 ## Resources Created
 
-This module creates the following resources.
+**Notice**: [Partitioning is not support when using Premium Messaging](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging#partitioned-queues-and-topics)
+
+This module creates the following resources:
 
 - [Azure Service Bus Topic](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_bus_topic)
 - [Azure Service Bus Subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_bus_subscription)
@@ -16,16 +18,15 @@ This module creates the following resources.
 ## Prerequisites
 
 - Terraform version 1.0.6+
-- AzureRM provider version 2.70.0+
+- AzureRM provider version 2.91.0+
 
 ## Arguments and defaults
 
 | Name | Type | Default | Required | Description |
 |-|-|-|-|-|
 | `name` | `string` | | **Required** | Specifies the name of the Service Bus Topic resource. Changing this forces a new resource to be created. The final name will be lowercased. |
-| `resource_group_name` | `string` | | **Required** | The name of the resource group in which to create the topic. Changing this forces a new resource to be created. |
-| `namespace_name` | `string` | | **Required** | The name of the Service Bus Namespace to create this topic in. Changing this forces a new resource to be created. |
-| `requires_session` | `false` | | | Boolean flag which controls whether the Queue requires sessions. This will allow ordered handling of unbounded sequences of related messages. With sessions enabled a queue can guarantee first-in-first-out delivery of messages. Changing this forces a new resource to be created. Defaults to false. |
+| `namespace_id` | `string` | | **Required** | The ID of the Service Bus Namespace to create this topic in. Changing this forces a new resource to be created. |
+| `requires_duplicate_detection` | `false` | | | Boolean flag which controls whether the Topic checks for duplicate messages within a time frame of 10 minutes (default). Changing this forces a new resource to be created. Defaults to false. |
 | `subscriptions` | `list` | `[]` | | A list of objects describing the subscriptions of the Service Bus Topic. See [Subscription](#subscription). |
 
 ### Subscription
@@ -39,10 +40,10 @@ This module creates the following resources.
 ## Usage
 
 ```ruby
-module "service_bus_topic_example" { 
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-topic?ref=5.1.0"
+module "service_bus_topic_example" {
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-topic?ref=6.0.0"
   name                = "example-name"
-  namespace_name      = "example-namespace-name"
+  namespace_id        = "/subscriptions/<subscription id>/resourceGroups/<resource group>/providers/Microsoft.ServiceBus/namespaces/example-namespace-name"
   subscriptions       = [
     {
       name                = "example-subscription-1"

--- a/azure/service-bus-topic/main.tf
+++ b/azure/service-bus-topic/main.tf
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 resource "azurerm_servicebus_topic" "this" {
-  name                = lower(var.name)
-  resource_group_name = var.resource_group_name
-  namespace_name      = var.namespace_name 
-  enable_partitioning = true
+  name                         = lower(var.name)
+  namespace_id                 = var.namespace_id
+  requires_duplicate_detection = var.requires_duplicate_detection
 }
 
 resource "azurerm_servicebus_subscription" "this" {
   count               = length(var.subscriptions)
 
   name                = lower(try(var.subscriptions[count.index].name, null))
-  namespace_name      = var.namespace_name
-  topic_name          = azurerm_servicebus_topic.this.name
+  topic_id            = azurerm_servicebus_topic.this.id
+
   max_delivery_count  = try(var.subscriptions[count.index].max_delivery_count, null)
   forward_to          = try(var.subscriptions[count.index].forward_to, null)
-  resource_group_name = var.resource_group_name
 }

--- a/azure/service-bus-topic/variables.tf
+++ b/azure/service-bus-topic/variables.tf
@@ -22,14 +22,15 @@ variable name {
   description = "(Required) Specifies the name of the Service Bus Topic resource. Changing this forces a new resource to be created."
 }
 
-variable resource_group_name {
+variable namespace_id {
   type        = string
-  description = "(Required) The name of the resource group in which to create the topic. Changing this forces a new resource to be created."
+  description = "(Required) The ID of the ServiceBus Namespace to create this topic in. Changing this forces a new resource to be created."
 }
 
-variable namespace_name {
-  type        = string
-  description = "(Required) The name of the Service Bus Namespace to create this topic in. Changing this forces a new resource to be created."
+variable requires_duplicate_detection {
+  type        = bool
+  description = "(Optional) Should the topic require duplicate detection? Defaults to false."
+  default     = false
 }
 
 variable subscriptions {
@@ -38,18 +39,6 @@ variable subscriptions {
     max_delivery_count  = number
     forward_to          = optional(string)
   }))
-  description = "(Optional) A mapping of tags to assign to the resource."
+  description = "(Optional) A list of objects describing the subscriptions of the Service Bus Topic."
   default = []
-}
-
-variable tags {
-  type        = any
-  description = "(Optional) A mapping of tags to assign to the resource."
-  default     = {}
-}
-
-variable dependencies {
-  type        = list
-  description = "A mapping of dependencies which this module depends on."
-  default     = []
 }


### PR DESCRIPTION
## Description

Some parameters has been deprecated in queue/topic, so we update the modules to match 2.91 versions.

Notice we have disabled partitioning on queues/topics because the Microsoft docs states its not supported with Premium Messaging anymore.
