### PR TITLE
5.12.0

### DIFF
--- a/azure/eventhub-namespace/variables.tf
+++ b/azure/eventhub-namespace/variables.tf
@@ -59,7 +59,7 @@ variable capacity {
 
 variable log_analytics_workspace_id {
   type = string
-  description = "(Required) The id of the Log Analytics Workspace where the API manager will log events (e.g. audit events) and metrics"
+  description = "(Required) The id of the Log Analytics Workspace where the Event Hub will log events (e.g. audit events) and metrics"
 }
 
 variable log_retention_in_days {

--- a/azure/function-app/README.md
+++ b/azure/function-app/README.md
@@ -26,7 +26,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "func_example" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.8.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "example-name"
   project_name                              = "example-project-name"
@@ -55,7 +55,7 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "5.9.0"
+    "ModuleVersion" = "5.12.0"
     "ModuleId"      = "azure-function-app"
   }
 }

--- a/azure/function-app/main.tf
+++ b/azure/function-app/main.tf
@@ -51,6 +51,7 @@ resource "azurerm_function_app" "this" {
   storage_account_name        = azurerm_storage_account.this.name
   storage_account_access_key  = azurerm_storage_account.this.primary_access_key
   version                     = "~4"
+  enable_builtin_logging      = false # Disabled to avoid having the setting "AzureWebJobsDashboard" when using Application Insights
   https_only                  = true
   app_settings                = merge({
     APPINSIGHTS_INSTRUMENTATIONKEY = var.application_insights_instrumentation_key

--- a/azure/function-app/main.tf
+++ b/azure/function-app/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "5.9.0",
+    "ModuleVersion" = "5.12.0",
     "ModuleId"      = "azure-function-app"
   }
 }
@@ -50,7 +50,7 @@ resource "azurerm_function_app" "this" {
   app_service_plan_id         = var.app_service_plan_id
   storage_account_name        = azurerm_storage_account.this.name
   storage_account_access_key  = azurerm_storage_account.this.primary_access_key
-  version                     = "~3"
+  version                     = "~4"
   https_only                  = true
   app_settings                = merge({
     APPINSIGHTS_INSTRUMENTATIONKEY = var.application_insights_instrumentation_key

--- a/azure/function-app/variables.tf
+++ b/azure/function-app/variables.tf
@@ -89,7 +89,7 @@ variable health_check_alert_enabled {
 
 variable log_analytics_workspace_id {
   type = string
-  description = "(Required) The id of the Log Analytics Workspace where the SQL DB will log events (e.g. audit events)"
+  description = "(Required) The id of the Log Analytics Workspace where the resources will log events (e.g. audit events)"
 }
 
 variable log_retention_in_days {

--- a/azure/key-vault/variables.tf
+++ b/azure/key-vault/variables.tf
@@ -67,7 +67,7 @@ variable enabled_for_template_deployment {
 
 variable log_analytics_workspace_id {
   type        = string
-  description = "(Required) The id of the Log Analytics Workspace where the keyvault will log events (e.g. audit events)"
+  description = "(Required) The id of the Log Analytics Workspace where the Key Vault will log events (e.g. audit events)"
 }
 
 variable log_retention_in_days {

--- a/azure/mssql-server/variables.tf
+++ b/azure/mssql-server/variables.tf
@@ -68,7 +68,7 @@ variable firewall_rules {
 
 variable log_analytics_workspace_id {
   type = string
-  description = "(Required) The id of the Log Analytics Workspace where the SQL DB will log events (e.g. audit events)"
+  description = "(Required) The id of the Log Analytics Workspace where the SQL Server will log events (e.g. audit events)"
 }
 
 variable log_retention_in_days {

--- a/azure/service-bus-namespace/variables.tf
+++ b/azure/service-bus-namespace/variables.tf
@@ -64,7 +64,7 @@ variable auth_rules {
 
 variable log_analytics_workspace_id {
   type = string
-  description = "(Optional) The id of the Log Analytics Workspace where theService Bus will log events (e.g. audit events)"
+  description = "(Optional) The id of the Log Analytics Workspace where the Service Bus will log events (e.g. audit events)"
   default = null
 }
 

--- a/azure/storage-account/variables.tf
+++ b/azure/storage-account/variables.tf
@@ -86,7 +86,7 @@ variable containers {
 
 variable log_analytics_workspace_id {
   type = string
-  description = "(Required) The id of the Log Analytics Workspace where the SQL DB will log events (e.g. audit events)"
+  description = "(Required) The id of the Log Analytics Workspace where the Storage Account will log events (e.g. audit events)"
 }
 
 variable log_retention_in_days {


### PR DESCRIPTION
## Description

Set functions to use v4 instead of v3.
Disable "built in logging" as recommended by MS (removing variable 'AzureWebJobsDashboard ').

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/3
