### PR TITLE
Make log workspace id mandatory for service bus namespace

### DIFF
--- a/azure/service-bus-namespace/README.md
+++ b/azure/service-bus-namespace/README.md
@@ -27,16 +27,17 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "service_bus_namespace_example" { 
-  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-namespace?ref=5.7.0"
+  source                      = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-namespace?ref=5.17.0"
 
-  name                  = "example-name"
-  project_name          = "example-project-name"
-  environment_short     = "p"
-  environment_instance  = "001"
-  resource_group_name   = "example-resource-group-name"
-  location              = "westeurope"
-  sku                   = "basic"
-  auth_rules            = [
+  name                        = "example-name"
+  project_name                = "example-project-name"
+  environment_short           = "p"
+  environment_instance        = "001"
+  resource_group_name         = "example-resource-group-name"
+  location                    = "westeurope"
+  sku                         = "basic"
+  log_analytics_workspace_id  = "example-log-analytics-workspace"
+  auth_rules                  = [
     {
       name    = "example-auth-rule-1"
       listen  = true
@@ -56,7 +57,7 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "5.7.0"
+    "ModuleVersion" = "5.17.0"
     "ModuleId"      = "azure-service-bus-namespace"
   }
 }

--- a/azure/service-bus-namespace/main.tf
+++ b/azure/service-bus-namespace/main.tf
@@ -47,7 +47,6 @@ resource "azurerm_servicebus_namespace_authorization_rule" "this" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "this" {
-  count                      = (var.log_analytics_workspace_id == null ? 0 : 1)
   name                       = "diag-sb-${lower(var.name)}-${lower(var.project_name)}-${lower(var.environment_short)}-${lower(var.environment_instance)}"
   target_resource_id         = azurerm_servicebus_namespace.this.id
   log_analytics_workspace_id = var.log_analytics_workspace_id

--- a/azure/service-bus-namespace/main.tf
+++ b/azure/service-bus-namespace/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "5.7.0"
+    "ModuleVersion" = "5.17.0"
     "ModuleId"      = "azure-service-bus-namespace"
   }
 }

--- a/azure/service-bus-namespace/variables.tf
+++ b/azure/service-bus-namespace/variables.tf
@@ -64,7 +64,7 @@ variable auth_rules {
 
 variable log_analytics_workspace_id {
   type = string
-  description = "(Optional) The id of the Log Analytics Workspace where the Service Bus will log events (e.g. audit events)"
+  description = "(Required) The id of the Log Analytics Workspace where the Service Bus will log events (e.g. audit events)"
 }
 
 variable log_retention_in_days {

--- a/azure/service-bus-namespace/variables.tf
+++ b/azure/service-bus-namespace/variables.tf
@@ -65,7 +65,6 @@ variable auth_rules {
 variable log_analytics_workspace_id {
   type = string
   description = "(Optional) The id of the Log Analytics Workspace where the Service Bus will log events (e.g. audit events)"
-  default = null
 }
 
 variable log_retention_in_days {


### PR DESCRIPTION
Log workspace ID is mandatory for all other types of resources where it can be used.