### PR TITLE
WIP: AD authentication for SQL Server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @renetnielsen @djorgensendk @Sondergaard @dstenroejl @Korgath @defectiveAi @lasrinnil @HenrikSommer @xnetsrak @Mech0z
+*       @renetnielsen @djorgensendk @dstenroejl @kerbou

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @renetnielsen @djorgensendk @Sondergaard @dstenroejl
+*       @renetnielsen @djorgensendk @Sondergaard @dstenroejl @Korgath @defectiveAi @lasrinnil @HenrikSommer @xnetsrak @Mech0z

--- a/azure/api-management-api-operation/README.md
+++ b/azure/api-management-api-operation/README.md
@@ -15,8 +15,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -26,7 +26,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "api_management_api_operation_example" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/api-management-api-operation?ref=6.0.0"
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/api-management-api-operation?ref=7.0.0"
 
   operation_id        = "example-operation-id"
   api_name            = "example-api-management-api-name"
@@ -56,7 +56,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "api-management-api-operation"
   }
 }

--- a/azure/api-management-api-operation/main.tf
+++ b/azure/api-management-api-operation/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "api-management-api-operation"
   }
 }

--- a/azure/api-management-api/README.md
+++ b/azure/api-management-api/README.md
@@ -15,8 +15,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -26,7 +26,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "apima_example" {
-  source                      = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/api-management-api?ref=6.0.0"
+  source                      = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/api-management-api?ref=7.0.0"
 
   name                        = "example-name"
   project_name                = "example-project-name"
@@ -64,7 +64,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-api-management-api"
   }
 }

--- a/azure/api-management-api/main.tf
+++ b/azure/api-management-api/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-api-management-api"
   }
 }

--- a/azure/api-management/README.md
+++ b/azure/api-management/README.md
@@ -16,8 +16,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -27,7 +27,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "apim_example" {
-  source                      = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/api-management?ref=6.0.0"
+  source                      = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/api-management?ref=7.0.0"
 
   name                        = "example-name"
   project_name                = "example-project-name"
@@ -49,7 +49,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-api-management"
   }
 }

--- a/azure/api-management/main.tf
+++ b/azure/api-management/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0",
     "ModuleId"      = "azure-api-management"
   }
 }

--- a/azure/app-service-plan/README.md
+++ b/azure/app-service-plan/README.md
@@ -15,8 +15,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -26,32 +26,16 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "plan_example" {
-<<<<<<< HEAD
-  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/app-service-plan?ref=6.0.0"
+  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/app-service-plan?ref=7.0.0"
 
-  name                  = "example-name"
-  project_name          = "example-project-name"
-  environment_short     = "u"
-  environment_instance  = "001"
-  resource_group_name   = "example-resource-group-name"
-  location              = "westeurope"
-  sku                   = {
-=======
-  source                         = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/app-service-plan?ref=5.11.0"
-
-  name                           = "example-name"
-  project_name                   = "example-project-name"
-  environment_short              = "p"
-  environment_instance           = "001"
-  resource_group_name            = "example-resource-group-name"
-  location                       = "westeurope"
-  monitor_alerts_action_group_id = "example-action-group-id"
-
-  sku                            = {
->>>>>>> a47859ad862856e0be46cb59862f6ccdd06514c7
-    tier = "Free"
-    size = "F1"
-  }
+  name                            = "example-name"
+  project_name                    = "example-project-name"
+  environment_short               = "u"
+  environment_instance            = "001"
+  resource_group_name             = "example-resource-group-name"
+  location                        = "westeurope"
+  monitor_alerts_action_group_id  = "example-action-group-id"
+  sku_name                        = "sku-name"
 
   tags                           = {}
 }
@@ -62,11 +46,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-<<<<<<< HEAD
-    "ModuleVersion" = "6.0.0",
-=======
-    "ModuleVersion" = "5.11.0",
->>>>>>> a47859ad862856e0be46cb59862f6ccdd06514c7
     "ModuleId"      = "azure-app-service-plan"
   }
 }

--- a/azure/app-service-plan/main.tf
+++ b/azure/app-service-plan/main.tf
@@ -13,22 +13,16 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0",
     "ModuleId"      = "azure-app-service-plan"
   }
 }
 
-resource "azurerm_app_service_plan" "this" {
+resource "azurerm_service_plan" "this" {
   name                = "plan-${lower(var.name)}-${lower(var.project_name)}-${lower(var.environment_short)}-${lower(var.environment_instance)}"
   resource_group_name = var.resource_group_name
   location            = var.location
-  kind                = var.kind
-  reserved            = var.reserved
-
-  sku {
-    size = var.sku.size
-    tier = var.sku.tier
-  }
+  os_type             = var.os_type
+  sku_name            = var.sku_name
 
   tags                = merge(var.tags, local.module_tags)
 
@@ -42,12 +36,12 @@ resource "azurerm_app_service_plan" "this" {
 }
 
 resource "azurerm_monitor_metric_alert" "metric_alert_cpu" {
-  name                = "ma-${azurerm_app_service_plan.this.name}-cpu"
+  name                = "ma-${azurerm_service_plan.this.name}-cpu"
   resource_group_name = var.resource_group_name
 
   enabled             = var.monitor_alerts_enabled
   severity            = 2
-  scopes              = [azurerm_app_service_plan.this.id]
+  scopes              = [azurerm_service_plan.this.id]
   description         = "Action will be triggered when average CPU usage is too high."
 
   frequency           = "PT1M"
@@ -77,12 +71,12 @@ resource "azurerm_monitor_metric_alert" "metric_alert_cpu" {
 }
 
 resource "azurerm_monitor_metric_alert" "metric_alert_memory" {
-  name                = "ma-${azurerm_app_service_plan.this.name}-mry"
+  name                = "ma-${azurerm_service_plan.this.name}-mry"
   resource_group_name = var.resource_group_name
 
   enabled             = var.monitor_alerts_enabled
   severity            = 2
-  scopes              = [azurerm_app_service_plan.this.id]
+  scopes              = [azurerm_service_plan.this.id]
   description         = "Action will be triggered when average memory usage is too high."
 
   frequency           = "PT1M"

--- a/azure/app-service-plan/outputs.tf
+++ b/azure/app-service-plan/outputs.tf
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 output id {
-  value       = azurerm_app_service_plan.this.id
+  value       = azurerm_service_plan.this.id
   description = "The ID of the App Service Plan component."
 }
 
 output name {
-  value       = azurerm_app_service_plan.this.name
+  value       = azurerm_service_plan.this.name
   description = "The name of the App Service Plan component."
 }

--- a/azure/app-service-plan/variables.tf
+++ b/azure/app-service-plan/variables.tf
@@ -41,23 +41,14 @@ variable location {
   description = "(Required) The Azure region where the resources are created. Changing this forces a new resource to be created."
 }
 
-variable kind {
+variable os_type {
   type        = string
-  description = "(Optional) The kind of the App Service Plan to create. Possible values are Windows (also available as App), Linux, elastic (for Premium Consumption) and FunctionApp (for a Consumption Plan). Defaults to Windows. Changing this forces a new resource to be created."
+  description = "(Required) The O/S type for the App Services to be hosted in this plan. Possible values include Windows, Linux, and WindowsContainer."
 }
 
-variable reserved {
-  type        = bool
-  description = "(Optional) Is this App Service Plan Reserved. Defaults to false."
-  default     = false
-}
-
-variable sku {
-  type        = object({
-    size  = string
-    tier  = string
-  })
-  description = "An object describing the sku for the App Service Plan."
+variable sku_name {
+  type        = string
+  description = "(Required) The SKU for the plan. Possible values include B1, B2, B3, D1, F1, FREE, I1, I2, I3, I1v2, I2v2, I3v2, P1v2, P2v2, P3v2, P1v3, P2v3, P3v3, S1, S2, S3, SHARED, EP1, EP2, EP3, WS1, WS2, and WS3"
 }
 
 variable monitor_alerts_action_group_id {

--- a/azure/app-service/README.md
+++ b/azure/app-service/README.md
@@ -22,8 +22,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -33,7 +33,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "app_example" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/app-service?ref=6.0.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/app-service?ref=7.0.0"
 
   name                                      = "example-name"
   project_name                              = "example-project-name"
@@ -66,7 +66,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-app-service"
   }
 }

--- a/azure/app-service/outputs.tf
+++ b/azure/app-service/outputs.tf
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 output id {
-  value       = azurerm_app_service.this.id
+  value       = azurerm_windows_web_app.this.id
   description = "The ID of the App Service."
 
   depends_on  = [
-    azurerm_app_service.this,
+    azurerm_windows_web_app.this,
     azurerm_app_service_virtual_network_swift_connection.this,
     azurerm_private_endpoint.this,
     azurerm_monitor_metric_alert.health_check_alert
@@ -24,23 +24,23 @@ output id {
 }
 
 output name {
-  value       = azurerm_app_service.this.name
+  value       = azurerm_windows_web_app.this.name
   description = "The name of the App Service."
 
   depends_on  = [
-    azurerm_app_service.this,
+    azurerm_windows_web_app.this,
     azurerm_app_service_virtual_network_swift_connection.this,
     azurerm_private_endpoint.this,
     azurerm_monitor_metric_alert.health_check_alert
   ]
 }
 
-output default_site_hostname {
-  value       = azurerm_app_service.this.default_site_hostname
+output default_hostname {
+  value       = azurerm_windows_web_app.this.default_hostname
   description = "The default hostname associated with the App Service - such as mysite.azurewebsites.net"
 
   depends_on  = [
-    azurerm_app_service.this,
+    azurerm_windows_web_app.this,
     azurerm_app_service_virtual_network_swift_connection.this,
     azurerm_private_endpoint.this,
     azurerm_monitor_metric_alert.health_check_alert
@@ -48,11 +48,11 @@ output default_site_hostname {
 }
 
 output outbound_ip_addresses {
-  value       = azurerm_app_service.this.outbound_ip_addresses
+  value       = azurerm_windows_web_app.this.outbound_ip_addresses
   description = "A comma separated list of outbound IP addresses - such as 52.23.25.3,52.143.43.12"
 
   depends_on  = [
-    azurerm_app_service.this,
+    azurerm_windows_web_app.this,
     azurerm_app_service_virtual_network_swift_connection.this,
     azurerm_private_endpoint.this,
     azurerm_monitor_metric_alert.health_check_alert
@@ -60,11 +60,11 @@ output outbound_ip_addresses {
 }
 
 output possible_outbound_ip_addresses {
-  value       = azurerm_app_service.this.possible_outbound_ip_addresses
+  value       = azurerm_windows_web_app.this.possible_outbound_ip_addresses
   description = "A comma separated list of outbound IP addresses - such as 52.23.25.3,52.143.43.12,52.143.43.17 - not all of which are necessarily in use. Superset of outbound_ip_addresses"
 
   depends_on  = [
-    azurerm_app_service.this,
+    azurerm_windows_web_app.this,
     azurerm_app_service_virtual_network_swift_connection.this,
     azurerm_private_endpoint.this,
     azurerm_monitor_metric_alert.health_check_alert
@@ -72,11 +72,11 @@ output possible_outbound_ip_addresses {
 }
 
 output identity {
-  value       = azurerm_app_service.this.identity
+  value       = azurerm_windows_web_app.this.identity
   description = "An identity block as defined below, which contains the Managed Service Identity information for this App Service."
 
   depends_on  = [
-    azurerm_app_service.this,
+    azurerm_windows_web_app.this,
     azurerm_app_service_virtual_network_swift_connection.this,
     azurerm_private_endpoint.this,
     azurerm_monitor_metric_alert.health_check_alert
@@ -84,11 +84,11 @@ output identity {
 }
 
 output site_credential {
-  value       = azurerm_app_service.this.site_credential
+  value       = azurerm_windows_web_app.this.site_credential
   description = "A site_credential block as defined below, which contains the site-level credentials used to publish to this App Service."
 
   depends_on  = [
-    azurerm_app_service.this,
+    azurerm_windows_web_app.this,
     azurerm_app_service_virtual_network_swift_connection.this,
     azurerm_private_endpoint.this,
     azurerm_monitor_metric_alert.health_check_alert

--- a/azure/app-service/variables.tf
+++ b/azure/app-service/variables.tf
@@ -80,8 +80,8 @@ variable connection_strings {
 
 variable dotnet_framework_version {
   type        = string
-  description = "(Optional) Use this when running on a Windows plan to specify .NET Core runtime version."
-  default     = "v5.0"
+  description = "(Optional) Use this to specify .NET runtime version."
+  default     = "v6.0"
 }
 
 variable always_on {

--- a/azure/application-insights/README.md
+++ b/azure/application-insights/README.md
@@ -14,8 +14,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -25,7 +25,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "appi_example" {
-  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/application-insights?ref=6.0.0"
+  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/application-insights?ref=7.0.0"
 
   name                  = "example-name"
   project_name          = "example-project-name"
@@ -44,7 +44,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-application-insights"
   }
 }

--- a/azure/application-insights/main.tf
+++ b/azure/application-insights/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0",
     "ModuleId"      = "azure-application-insights"
   }
 }

--- a/azure/cosmos-db-account/README.md
+++ b/azure/cosmos-db-account/README.md
@@ -15,8 +15,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.2+
-- AzureRM provider version 2.91.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -26,7 +26,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "cosmos_db_example" {
-  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/cosmos-db-account?ref=6.0.0"
+  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/cosmos-db-account?ref=7.0.0"
 
   name                            = "example-name"
   project_name                    = "example-project-name"
@@ -45,7 +45,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-cosmos-db-account"
   }
 }

--- a/azure/cosmos-db-account/main.tf
+++ b/azure/cosmos-db-account/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-cosmos-db-account"
   }
 }

--- a/azure/databricks-workspace/README.md
+++ b/azure/databricks-workspace/README.md
@@ -17,8 +17,8 @@ This module creates the following resources.
 
 ## Prerequisites
 
-- Terraform version 1.1.2+
-- AzureRM provider version 2.91.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -28,7 +28,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "dbw_example" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/databricks-workspace?ref=6.0.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/databricks-workspace?ref=7.0.0"
 
   name                                      = "example-name"
   project_name                              = "example-project-name"
@@ -53,7 +53,6 @@ Two tags are added by default
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-databricks-workspace"
   }
 }

--- a/azure/databricks-workspace/main.tf
+++ b/azure/databricks-workspace/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-databricks-workspace"
   }
   NAME = "vnet-${lower(var.name)}-${lower(var.project_name)}-${lower(var.environment_short)}-${lower(var.environment_instance)}"

--- a/azure/eventhub-namespace/README.md
+++ b/azure/eventhub-namespace/README.md
@@ -16,8 +16,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -27,7 +27,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "eventhub_namespace_example" {
-  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/eventhub-namespace?ref=6.0.0"
+  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/eventhub-namespace?ref=7.0.0"
 
   name                            = "example-name"
   project_name                    = "example-project-name"
@@ -47,7 +47,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-eventhub-namespace"
   }
 }

--- a/azure/eventhub-namespace/main.tf
+++ b/azure/eventhub-namespace/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-eventhub-namespace"
   }
 }

--- a/azure/eventhub/README.md
+++ b/azure/eventhub/README.md
@@ -15,8 +15,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -26,7 +26,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "eventhub_example" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/eventhub?ref=6.0.0"
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/eventhub?ref=7.0.0"
   name                = "example-name"
   namespace_name      = "example-namespace-name"
   resource_group_name = "example-resource-group-name"

--- a/azure/function-app/README.md
+++ b/azure/function-app/README.md
@@ -27,8 +27,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -38,7 +38,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "func_example" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=6.0.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=7.0.0"
 
   name                                      = "example-name"
   project_name                              = "example-project-name"
@@ -75,7 +75,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-function-app"
   }
 }

--- a/azure/function-app/outputs.tf
+++ b/azure/function-app/outputs.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 output id {
-  value       = azurerm_function_app.this.id
+  value       = azurerm_windows_function_app.this.id
   description = "The ID of the Function App."
 
   depends_on  = [
@@ -21,13 +21,13 @@ output id {
     azurerm_private_endpoint.blob,
     azurerm_private_endpoint.file,
     azurerm_app_service_virtual_network_swift_connection.this,
-    azurerm_function_app.this,
+    azurerm_windows_function_app.this,
     azurerm_private_endpoint.this,
   ]
 }
 
 output name {
-  value       = azurerm_function_app.this.name
+  value       = azurerm_windows_function_app.this.name
   description = "The name of the Function App."
 
   depends_on  = [
@@ -36,12 +36,12 @@ output name {
     azurerm_private_endpoint.blob,
     azurerm_private_endpoint.file,
     azurerm_app_service_virtual_network_swift_connection.this,
-    azurerm_function_app.this,
+    azurerm_windows_function_app.this,
   ]
 }
 
 output default_hostname {
-  value       = azurerm_function_app.this.default_hostname
+  value       = azurerm_windows_function_app.this.default_hostname
   description = "The default hostname associated with the Function App - such as mysite.azurewebsites.net"
 
   depends_on  = [
@@ -50,13 +50,13 @@ output default_hostname {
     azurerm_private_endpoint.blob,
     azurerm_private_endpoint.file,
     azurerm_app_service_virtual_network_swift_connection.this,
-    azurerm_function_app.this,    
+    azurerm_windows_function_app.this,
     azurerm_private_endpoint.this,
   ]
 }
 
 output outbound_ip_addresses {
-  value       = azurerm_function_app.this.outbound_ip_addresses
+  value       = azurerm_windows_function_app.this.outbound_ip_addresses
   description = "A comma separated list of outbound IP addresses - such as 52.23.25.3,52.143.43.12"
 
   depends_on  = [
@@ -65,13 +65,13 @@ output outbound_ip_addresses {
     azurerm_private_endpoint.blob,
     azurerm_private_endpoint.file,
     azurerm_app_service_virtual_network_swift_connection.this,
-    azurerm_function_app.this,
+    azurerm_windows_function_app.this,
     azurerm_private_endpoint.this,
   ]
 }
 
 output possible_outbound_ip_addresses {
-  value       = azurerm_function_app.this.possible_outbound_ip_addresses
+  value       = azurerm_windows_function_app.this.possible_outbound_ip_addresses
   description = "A comma separated list of outbound IP addresses - such as 52.23.25.3,52.143.43.12,52.143.43.17 - not all of which are necessarily in use. Superset of outbound_ip_addresses"
 
   depends_on  = [
@@ -80,13 +80,13 @@ output possible_outbound_ip_addresses {
     azurerm_private_endpoint.blob,
     azurerm_private_endpoint.file,
     azurerm_app_service_virtual_network_swift_connection.this,
-    azurerm_function_app.this,
+    azurerm_windows_function_app.this,
     azurerm_private_endpoint.this,
   ]
 }
 
 output identity {
-  value       = azurerm_function_app.this.identity
+  value       = azurerm_windows_function_app.this.identity
   description = "An identity block as defined below, which contains the Managed Service Identity information for this App Service."
 
   depends_on  = [
@@ -95,13 +95,13 @@ output identity {
     azurerm_private_endpoint.blob,
     azurerm_private_endpoint.file,
     azurerm_app_service_virtual_network_swift_connection.this,
-    azurerm_function_app.this,
+    azurerm_windows_function_app.this,
     azurerm_private_endpoint.this,
   ]
 }
 
 output site_credential {
-  value       = azurerm_function_app.this.site_credential
+  value       = azurerm_windows_function_app.this.site_credential
   description = "A site_credential block as defined below, which contains the site-level credentials used to publish to this App Service."
 
   depends_on  = [
@@ -110,13 +110,13 @@ output site_credential {
     azurerm_private_endpoint.blob,
     azurerm_private_endpoint.file,
     azurerm_app_service_virtual_network_swift_connection.this,
-    azurerm_function_app.this,
+    azurerm_windows_function_app.this,
     azurerm_private_endpoint.this,
   ]
 }
 
 output kind {
-  value       = azurerm_function_app.this.kind
+  value       = azurerm_windows_function_app.this.kind
   description = "The Function App kind - such as functionapp,linux,container"
 
   depends_on  = [
@@ -125,7 +125,7 @@ output kind {
     azurerm_private_endpoint.blob,
     azurerm_private_endpoint.file,
     azurerm_app_service_virtual_network_swift_connection.this,
-    azurerm_function_app.this,
+    azurerm_windows_function_app.this,
     azurerm_private_endpoint.this,
   ]
 }

--- a/azure/function-app/variables.tf
+++ b/azure/function-app/variables.tf
@@ -77,6 +77,24 @@ variable connection_strings {
   default     = []
 }
 
+variable functions_extension_version {
+  type        = string
+  description = "(Optional) The runtime version associated with the Function App."
+  default     = "~4"
+}
+
+variable dotnet_framework_version {
+  type        = string
+  description = "(Optional) Use this to specify .NET runtime version."
+  default     = "6"
+}
+
+variable use_dotnet_isolated_runtime {
+  type        = bool
+  description = "(Optional) Should the .NET process use an isolated runtime."
+  default     = true
+}
+
 variable always_on {
   type        = bool
   description = "(Optional) Should the Function App be loaded at all times? Defaults to false."

--- a/azure/key-vault-access-policy/README.md
+++ b/azure/key-vault-access-policy/README.md
@@ -14,8 +14,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -25,7 +25,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "key_vault_access_policy_example" {
-  source        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault-access-policy?ref=6.1.0"
+  source        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault-access-policy?ref=7.0.0"
 
   key_vault_id  = "example-key-vault-id"
   app_identity {
@@ -40,7 +40,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.1.0"
     "ModuleId"      = "key-vault-access-policy"
   }
 }

--- a/azure/key-vault-access-policy/main.tf
+++ b/azure/key-vault-access-policy/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.1.0"
     "ModuleId"      = "azure-key-vault-access-polity"
   }
 }

--- a/azure/key-vault-secret/README.md
+++ b/azure/key-vault-secret/README.md
@@ -14,8 +14,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -25,7 +25,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "key_vault_secret_example" {
-  source        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault-secret?ref=6.0.0"
+  source        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault-secret?ref=7.0.0"
 
   name          = "EXAMPLE-NAME"
   value         = "example-value"
@@ -40,7 +40,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-key-vault-secret"
   }
 }

--- a/azure/key-vault-secret/main.tf
+++ b/azure/key-vault-secret/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0",
     "ModuleId"      = "azure-key-vault-secret"
   }
 }

--- a/azure/key-vault/README.md
+++ b/azure/key-vault/README.md
@@ -17,8 +17,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -28,7 +28,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "key_vault_example" {
-  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault?ref=6.0.0"
+  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault?ref=7.0.0"
 
   name                            = "example-name"
   project_name                    = "example-project-name"
@@ -66,7 +66,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-key-vault"
   }
 }

--- a/azure/key-vault/main.tf
+++ b/azure/key-vault/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-key-vault"
   }
 }
@@ -84,28 +83,28 @@ resource "azurerm_key_vault_access_policy" "selfpermissions" {
   tenant_id               = data.azurerm_client_config.this.tenant_id
   object_id               = data.azurerm_client_config.this.object_id
   secret_permissions      = [
-    "delete",
-    "list",
-    "get",
-    "set",
-    "purge"
+    "Delete",
+    "List",
+    "Get",
+    "Set",
+    "Purge"
   ]
   key_permissions         = [
-    "create",
-    "list",
-    "delete",
-    "get"
+    "Create",
+    "List",
+    "Delete",
+    "Get"
   ]
   certificate_permissions = [
-    "create",
-    "list",
-    "delete",
-    "get"
+    "Create",
+    "List",
+    "Delete",
+    "Get"
   ]
   storage_permissions     = [
-    "delete",
-    "get",
-    "set"
+    "Delete",
+    "Get",
+    "Set"
   ]
 }
 

--- a/azure/log-workspace/README.md
+++ b/azure/log-workspace/README.md
@@ -14,8 +14,8 @@ This module creates the following resource:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -25,7 +25,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "log_workspace_example" {
-  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/log-workspace?ref=5.6.0"
+  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/log-workspace?ref=7.0.0"
 
   name                  = "example-name"
   project_name          = "example-project"
@@ -43,7 +43,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "5.6.0"
     "ModuleId"      = "azure-log-workspace"
   }
 }

--- a/azure/log-workspace/main.tf
+++ b/azure/log-workspace/main.tf
@@ -14,7 +14,6 @@
 
 locals {
   module_tags = {
-    "ModuleVersion" = "5.6.0"
     "ModuleId"      = "azure-log-workspace"
   }
 }

--- a/azure/monitor-action-group-email/README.md
+++ b/azure/monitor-action-group-email/README.md
@@ -14,8 +14,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -25,7 +25,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "monitor_action_group_email_example" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/monitor-action-group-email?ref=5.8.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/monitor-action-group-email?ref=7.0.0"
 
   name                                      = "example-name"
   project_name                              = "example-project-name"
@@ -46,7 +46,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "5.8.0"
     "ModuleId"      = "monitor-action-group-email"
   }
 }

--- a/azure/monitor-action-group-email/main.tf
+++ b/azure/monitor-action-group-email/main.tf
@@ -14,7 +14,6 @@
 
 locals {
   module_tags = {
-    "ModuleVersion" = "5.8.0"
     "ModuleId"      = "monitor-action-group-email"
   }
 }

--- a/azure/mssql-database/README.md
+++ b/azure/mssql-database/README.md
@@ -15,8 +15,8 @@ This module creates the following resource:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -26,7 +26,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "sqldb_example" {
-  source                        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/mssql-database?ref=6.0.0"
+  source                        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/mssql-database?ref=7.0.0"
 
   name                          = "example-name"
   project_name                  = "example-project-name"
@@ -45,7 +45,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-mssql-database"
   }
 }

--- a/azure/mssql-database/main.tf
+++ b/azure/mssql-database/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-mssql-database"
   }
 }

--- a/azure/mssql-server/README.md
+++ b/azure/mssql-server/README.md
@@ -17,8 +17,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -28,7 +28,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "sql_server_example" {
-  source                        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/mssql-server?ref=6.0.0"
+  source                        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/mssql-server?ref=7.0.0"
 
   name                            = "example-name"
   project_name                    = "example-project-name"
@@ -51,7 +51,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-mssql-server"
   }
 }

--- a/azure/mssql-server/main.tf
+++ b/azure/mssql-server/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-mssql-server"
   }
 }

--- a/azure/service-bus-namespace/README.md
+++ b/azure/service-bus-namespace/README.md
@@ -20,8 +20,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -31,7 +31,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "service_bus_namespace_example" {
-  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-namespace?ref=6.0.0"
+  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-namespace?ref=7.0.0"
 
   name                            = "example-name"
   project_name                    = "example-project-name"
@@ -41,7 +41,7 @@ module "service_bus_namespace_example" {
   location                        = "westeurope"
   private_endpoint_subnet_id      = "private-endpoint-subnet-id"
   log_analytics_workspace_id      = "example-log-analytics-workspace"
-  
+
   auth_rules            = [
     {
       name    = "example-auth-rule-1"
@@ -64,7 +64,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-service-bus-namespace"
   }
 }

--- a/azure/service-bus-namespace/main.tf
+++ b/azure/service-bus-namespace/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-service-bus-namespace"
   }
 }

--- a/azure/service-bus-queue/README.md
+++ b/azure/service-bus-queue/README.md
@@ -8,25 +8,15 @@
 
 ## Resources Created
 
-<<<<<<< HEAD
 **Notice**: [Partitioning is not support when using Premium Messaging](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging#partitioned-queues-and-topics)
-=======
-This module creates the following resources:
->>>>>>> a47859ad862856e0be46cb59862f6ccdd06514c7
-
 This module creates the following resources:
 
 - [Azure Service Bus Queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_queue)
 
 ## Prerequisites
 
-<<<<<<< HEAD
-- Terraform version 1.1.2+
-- AzureRM provider version 2.91.0+
-=======
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
->>>>>>> a47859ad862856e0be46cb59862f6ccdd06514c7
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -36,7 +26,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "service_bus_queue_example" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-queue?ref=6.0.0"
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-queue?ref=7.0.0"
   name                = "example-name"
   namespace_id        = "/subscriptions/<subscription id>/resourceGroups/<resource group>/providers/Microsoft.ServiceBus/namespaces/example-namespace-name"
 }

--- a/azure/service-bus-topic/README.md
+++ b/azure/service-bus-topic/README.md
@@ -17,8 +17,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -28,7 +28,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "service_bus_topic_example" {
-  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-topic?ref=6.0.0"
+  source              = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/service_bus-topic?ref=7.0.0"
   name                = "example-name"
   namespace_id        = "/subscriptions/<subscription id>/resourceGroups/<resource group>/providers/Microsoft.ServiceBus/namespaces/example-namespace-name"
 

--- a/azure/storage-account-dfs/README.md
+++ b/azure/storage-account-dfs/README.md
@@ -18,8 +18,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -29,7 +29,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "storage_account_dfs_example" {
-  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/storage-account-dfs?ref=6.0.0"
+  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/storage-account-dfs?ref=7.0.0"
 
   name                            = "example-name"
   project_name                    = "example-project-name"
@@ -53,7 +53,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-storage-account-dfs"
   }
 }

--- a/azure/storage-account-dfs/main.tf
+++ b/azure/storage-account-dfs/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-storage-account-dfs"
   }
 }

--- a/azure/storage-account/README.md
+++ b/azure/storage-account/README.md
@@ -19,8 +19,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.7+
-- AzureRM provider version 2.97.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -30,7 +30,7 @@ See [variables.tf](./variables.tf)
 
 ```ruby
 module "storage_account_example" {
-  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/storage-account?ref=6.0.0"
+  source                          = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/storage-account?ref=7.0.0"
 
   name                            = "example-name"
   project_name                    = "example-project-name"
@@ -61,7 +61,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-storage-account"
   }
 }

--- a/azure/storage-account/main.tf
+++ b/azure/storage-account/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-storage-account"
   }
 }

--- a/azure/subnet/README.md
+++ b/azure/subnet/README.md
@@ -14,8 +14,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.2+
-- AzureRM provider version 2.91.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -35,7 +35,7 @@ An `delegation` item consists of the following:
 
 ```ruby
 module "snet_example" {
-  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/subnet?ref=6.0.0"
+  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/subnet?ref=7.0.0"
 
   name                  = "example-name"
   project_name          = "example-project-name"

--- a/azure/vnet/README.md
+++ b/azure/vnet/README.md
@@ -15,8 +15,8 @@ This module creates the following resources:
 
 ## Prerequisites
 
-- Terraform version 1.1.2+
-- AzureRM provider version 2.91.0+
+- Terraform version 1.2.2+
+- AzureRM provider version 3.9.0+
 
 ## Arguments and defaults
 
@@ -37,7 +37,7 @@ An `peering` item consists of the following:
 
 ```ruby
 module "vnet_example" {
-  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/vnet?ref=6.0.0"
+  source                = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/vnet?ref=7.0.0"
 
   name                  = "example-name"
   project_name          = "example-project-name"
@@ -66,7 +66,6 @@ Two tags are added by default:
 ```ruby
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0"
     "ModuleId"      = "azure-subnet"
   }
 }

--- a/azure/vnet/main.tf
+++ b/azure/vnet/main.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 locals {
   module_tags = {
-    "ModuleVersion" = "6.0.0",
     "ModuleId"      = "azure-vnet"
   }
 }


### PR DESCRIPTION
## Description

Change TF module SQL Server to support AD authentication:

* Set deployment Service Principal as Azure Active Directory (Azure AD) administrator.
* New variable: "ad_authentication_only" default value = false at first; later we can change it to true.

Change TF module SQL Database to support AD authentication:

* Allow configuration (list) of Azure AD users permissions (assignments to fixed database roles) - remember "DataHub developer group" should be "db_datareader".

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/401